### PR TITLE
Fix missing comma in setup.py requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ setup(
     install_requires=[
         "mypy>=0.750",
         "django-stubs>=1.3.0",
-        "djangorestframework-stubs>=0.4.0" "typing-extensions>=3.7.4",
+        "djangorestframework-stubs>=0.4.0",
+        "typing-extensions>=3.7.4",
     ],
     classifiers=[
         "Development Status :: 1 - Planning",


### PR DESCRIPTION
This bug was found thanks to Poetry:

> PackageInfo: Invalid constraint (djangorestframework-stubs>=0.4.0typing-extensions>=3.7.4) found in django-filter-stubs-0.1.1 dependencies, skipping
