### PR TITLE
Explicitly export all the filters from the rest_framework module

### DIFF
--- a/django_filters-stubs/rest_framework/__init__.pyi
+++ b/django_filters-stubs/rest_framework/__init__.pyi
@@ -1,3 +1,38 @@
 from .backends import DjangoFilterBackend as DjangoFilterBackend
 from .filters import *
 from .filterset import FilterSet as FilterSet
+
+__all__ = [
+    "DjangoFilterBackend",
+    "FilterSet",
+    "BooleanFilter",
+    "AllValuesFilter",
+    "AllValuesMultipleFilter",
+    "BaseCSVFilter",
+    "BaseInFilter",
+    "BaseRangeFilter",
+    "CharFilter",
+    "ChoiceFilter",
+    "DateFilter",
+    "DateFromToRangeFilter",
+    "DateRangeFilter",
+    "DateTimeFilter",
+    "DateTimeFromToRangeFilter",
+    "DurationFilter",
+    "Filter",
+    "IsoDateTimeFilter",
+    "IsoDateTimeFromToRangeFilter",
+    "LookupChoiceFilter",
+    "ModelChoiceFilter",
+    "ModelMultipleChoiceFilter",
+    "MultipleChoiceFilter",
+    "NumberFilter",
+    "NumericRangeFilter",
+    "OrderingFilter",
+    "RangeFilter",
+    "TimeFilter",
+    "TimeRangeFilter",
+    "TypedChoiceFilter",
+    "TypedMultipleChoiceFilter",
+    "UUIDFilter",
+]

--- a/django_filters-stubs/rest_framework/filters.pyi
+++ b/django_filters-stubs/rest_framework/filters.pyi
@@ -1,37 +1,70 @@
 from typing import Any
 
-from django_filters import filters
+from django_filters import (
+    filters,
+    AllValuesFilter,
+    AllValuesMultipleFilter,
+    BaseCSVFilter,
+    BaseInFilter,
+    BaseRangeFilter,
+    CharFilter,
+    ChoiceFilter,
+    DateFilter,
+    DateFromToRangeFilter,
+    DateRangeFilter,
+    DateTimeFilter,
+    DateTimeFromToRangeFilter,
+    DurationFilter,
+    Filter,
+    IsoDateTimeFilter,
+    IsoDateTimeFromToRangeFilter,
+    LookupChoiceFilter,
+    ModelChoiceFilter,
+    ModelMultipleChoiceFilter,
+    MultipleChoiceFilter,
+    NumberFilter,
+    NumericRangeFilter,
+    OrderingFilter,
+    RangeFilter,
+    TimeFilter,
+    TimeRangeFilter,
+    TypedChoiceFilter,
+    TypedMultipleChoiceFilter,
+    UUIDFilter,
+)
 
 class BooleanFilter(filters.BooleanFilter):
     def __init__(self, *args: Any, **kwargs: Any) -> None: ...
 
-# Names in __all__ with no definition:
-#   AllValuesFilter
-#   AllValuesMultipleFilter
-#   BaseCSVFilter
-#   BaseInFilter
-#   BaseRangeFilter
-#   CharFilter
-#   ChoiceFilter
-#   DateFilter
-#   DateFromToRangeFilter
-#   DateRangeFilter
-#   DateTimeFilter
-#   DateTimeFromToRangeFilter
-#   DurationFilter
-#   Filter
-#   IsoDateTimeFilter
-#   IsoDateTimeFromToRangeFilter
-#   LookupChoiceFilter
-#   ModelChoiceFilter
-#   ModelMultipleChoiceFilter
-#   MultipleChoiceFilter
-#   NumberFilter
-#   NumericRangeFilter
-#   OrderingFilter
-#   RangeFilter
-#   TimeFilter
-#   TimeRangeFilter
-#   TypedChoiceFilter
-#   TypedMultipleChoiceFilter
-#   UUIDFilter
+__all__ = [
+    "BooleanFilter",
+    "AllValuesFilter",
+    "AllValuesMultipleFilter",
+    "BaseCSVFilter",
+    "BaseInFilter",
+    "BaseRangeFilter",
+    "CharFilter",
+    "ChoiceFilter",
+    "DateFilter",
+    "DateFromToRangeFilter",
+    "DateRangeFilter",
+    "DateTimeFilter",
+    "DateTimeFromToRangeFilter",
+    "DurationFilter",
+    "Filter",
+    "IsoDateTimeFilter",
+    "IsoDateTimeFromToRangeFilter",
+    "LookupChoiceFilter",
+    "ModelChoiceFilter",
+    "ModelMultipleChoiceFilter",
+    "MultipleChoiceFilter",
+    "NumberFilter",
+    "NumericRangeFilter",
+    "OrderingFilter",
+    "RangeFilter",
+    "TimeFilter",
+    "TimeRangeFilter",
+    "TypedChoiceFilter",
+    "TypedMultipleChoiceFilter",
+    "UUIDFilter",
+]

--- a/django_filters-stubs/rest_framework/filters.pyi
+++ b/django_filters-stubs/rest_framework/filters.pyi
@@ -1,7 +1,6 @@
 from typing import Any
 
 from django_filters import (
-    filters,
     AllValuesFilter,
     AllValuesMultipleFilter,
     BaseCSVFilter,
@@ -31,6 +30,7 @@ from django_filters import (
     TypedChoiceFilter,
     TypedMultipleChoiceFilter,
     UUIDFilter,
+    filters,
 )
 
 class BooleanFilter(filters.BooleanFilter):

--- a/tests/test_rest_framework.yml
+++ b/tests/test_rest_framework.yml
@@ -1,0 +1,6 @@
+- case: rest_framework
+  main: |
+    from django_filters import rest_framework as filters
+
+    class TestFilter(filters.FilterSet):
+      special_date = filters.DateFilter() # Mypy: Module has no attribute "DateFilter" [attr-defined]


### PR DESCRIPTION
Fixes https://github.com/DavisRayM/django-filter-stubs/issues/11

In theory, you should be able to do some sort of magic with `dir` and maps rather than this mess of copy/paste, but it doesn't seem to work for `.pyi` files :(